### PR TITLE
prevent setContentOffset when has zero items

### DIFF
--- a/LCFInfiniteScrollView/LCFInfiniteScrollView/LCFInfiniteScrollView.m
+++ b/LCFInfiniteScrollView/LCFInfiniteScrollView/LCFInfiniteScrollView.m
@@ -154,6 +154,7 @@
 }
 
 - (void)timerFire:(NSTimer *)timer {
+    if (self.items.count == 0) return;
     CGFloat currentOffset = self.collectionView.contentOffset.x;
     CGFloat targetOffset  = currentOffset + self.itemSize.width + self.itemSpacing;
     


### PR DESCRIPTION
避免没有items的时候去设置setContentOffset从而导致 reportStatus 中的index计算引起的崩溃
